### PR TITLE
Log resources marked for future deletion

### DIFF
--- a/reap
+++ b/reap
@@ -71,7 +71,10 @@ resourceGroups.concat(resources).forEach(resource => {
     const now = atMidnight(new Date());
 
     // If the resource hasn't expired yet then just exit
-    if (expiresAt > now) return;
+    if (expiresAt > now) {
+        console.log(`Resource ${resource.name} matches for reaping but has not yet expired. It will be reaped at ${expiresAt.toDateString()}`);
+        return;
+    }
 
     expiredResources.push(resource);
 });


### PR DESCRIPTION
This was my tiny change - I wanted to see what resources were picked-up for future deletion.
I added logging to see resources that had been identified as "delete candidates" but which hadn't yet expired.
That way I could create a new resource group in a subscription and see straight away if it was correctly marked for deletion.
(I also temporarily disabled the `az resource delete` for the test - can't see an easy way to bake that in though).