### PR TITLE
Resources and resource groups either named or tagged will be culled

### DIFF
--- a/reap
+++ b/reap
@@ -41,7 +41,7 @@ const resourceGroups = JSON.parse(az([
     , '--url-parameters'
     , 'api-version=2021-04-01', '$expand=createdTime', '$select=id,name,createdTime'
     , '--query'
-    , `value | [? contains(name, 'delete')] | [].{id: id, name: name, createdTime: createdTime, tags: tags}`
+    , `value | [? contains(name, 'delete') || tags.delete] | [].{id: id, name: name, createdTime: createdTime, tags: tags}`
 ]));
 
 // Find any individual resources tagged with 'delete'
@@ -54,7 +54,7 @@ const resources = JSON.parse(az([
     , '--url-parameters'
     , 'api-version=2021-04-01', "$expand=createdTime", "$select=id,name,createdTime"
     , '--query'
-    , 'value | [? tags.delete].{id: id, name: name, createdTime: createdTime, tags: tags}'
+    , `value | [? contains(name, 'delete') || tags.delete].{id: id, name: name, createdTime: createdTime, tags: tags}`
 ]));
 
 


### PR DESCRIPTION
Previously there was an issue where if a resource group was tagged 'delete:1' it would be ignored

This was because only resources were checked if they were tagged. The same was also true for if a resource was named 'delete-me'.

It is now even more important to make sure that you haven't got a resource called do-not-delete :)